### PR TITLE
fix: Update spatial resolution to be in meters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ number as needed.
 - Close file handles ([#21](https://github.com/stactools-packages/sentinel3/pull/21))
 - Prevent addition of `'s3:shape'` to safe-manifest asset
   ([#22](https://github.com/stactools-packages/sentinel3/pull/23))
+- Make `s3:spatial_resolution` unit meters ([#29](https://github.com/stactools-packages/sentinel3/pull/29))
 
 ## [0.4.0] - 2023-03-31
 

--- a/examples/S3B_SL_2_WST_20210419T051754_20210419T065853_6059_051_247.json
+++ b/examples/S3B_SL_2_WST_20210419T051754_20210419T065853_6059_051_247.json
@@ -1131,8 +1131,8 @@
       "type": "application/x-netcdf",
       "description": "Data respects the Group for High Resolution Sea Surface Temperature (GHRSST) L2P specification",
       "s3:spatial_resolution": [
-        1,
-        1
+        1000,
+        1000
       ],
       "eo:bands": [
         {

--- a/src/stactools/sentinel3/metadata_links.py
+++ b/src/stactools/sentinel3/metadata_links.py
@@ -90,8 +90,8 @@ class MetadataLinks:
             if spatres_str.endswith(tail):
                 asset_resolution_str = spatres_str.replace(tail, "")
                 asset_resolution = [
-                    int(asset_resolution_str),
-                    int(asset_resolution_str),
+                    int(asset_resolution_str) * 1000,
+                    int(asset_resolution_str) * 1000,
                 ]
             else:
                 raise ValueError(


### PR DESCRIPTION
**Related Issue(s):**

- Closes #27 

**Description:**

Multiply km value by 1000 to set `s3:spatial_resolution` to be meters (following in the footsteps of the raster extension and gsd properties, both of which specify meters)

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
