### PR TITLE
prevent EO from being added to altimetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ number as needed.
 - Prevent addition of `'s3:shape'` to safe-manifest asset
   ([#22](https://github.com/stactools-packages/sentinel3/pull/23))
 - Make `s3:spatial_resolution` unit meters ([#29](https://github.com/stactools-packages/sentinel3/pull/29))
+- Don't add EO extension to radar products
+  ([#26](https://github.com/stactools-packages/sentinel3/pull/30))
 
 ## [0.4.0] - 2023-03-31
 

--- a/examples/S3A_SR_2_LAN_20210611T011438_20210611T012436_0598_072_373.json
+++ b/examples/S3A_SR_2_LAN_20210611T011438_20210611T012436_0598_072_373.json
@@ -317,7 +317,6 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
-    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/eo/v1.1.0/schema.json"
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
   ]
 }

--- a/examples/S3A_SR_2_WAT_20210704T012815_20210704T021455_2800_073_316.json
+++ b/examples/S3A_SR_2_WAT_20210704T012815_20210704T021455_2800_073_316.json
@@ -901,7 +901,6 @@
   ],
   "stac_extensions": [
     "https://stac-extensions.github.io/file/v2.1.0/schema.json",
-    "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/eo/v1.1.0/schema.json"
+    "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
   ]
 }

--- a/src/stactools/sentinel3/stac.py
+++ b/src/stactools/sentinel3/stac.py
@@ -205,8 +205,9 @@ def create_item(
     fill_sat_properties(sat, metalinks.manifest)
 
     # eo
-    eo = EOExtension.ext(item, add_if_missing=True)
-    fill_eo_properties(eo, metalinks.manifest)
+    if sen3naming.group("datatype") not in ("WAT___", "LAN___"):
+        eo = EOExtension.ext(item, add_if_missing=True)
+        fill_eo_properties(eo, metalinks.manifest)
 
     # s3 properties
     item.properties.update({**product_metadata.metadata_dict})
@@ -356,4 +357,5 @@ def create_item(
         list(geometry_dict["coordinates"]), precision=4
     )
     item.geometry = geometry_dict
+
     return item

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -402,10 +402,14 @@ class CreateItemTest(CliTestCase):
                 for _, asset in item.assets.items():
                     self.assertTrue("/./" not in asset.href)
                     self.assertTrue(is_absolute_href(asset.href))
-                    asset_eo = EOExtension.ext(asset)
-                    bands = asset_eo.bands
-                    if bands is not None:
-                        bands_seen |= set(b.name for b in bands)
+                    bands = set(
+                        [
+                            band["frequency_band"]
+                            for band in asset.extra_fields.get("s3:altimetry_bands", [])
+                        ]
+                    )
+                    if bands:
+                        bands_seen |= bands
 
                 [self.assertTrue(band in band_list) for band in bands_seen]
                 os.remove(f"{tmp_dir}/{item_id}.json")
@@ -441,11 +445,14 @@ class CreateItemTest(CliTestCase):
                 for _, asset in item.assets.items():
                     self.assertTrue("/./" not in asset.href)
                     self.assertTrue(is_absolute_href(asset.href))
-                    asset_eo = EOExtension.ext(asset)
-                    bands = asset_eo.bands
-                    if bands is not None:
-                        bands_seen |= set(b.name for b in bands)
-
+                    bands = set(
+                        [
+                            band["frequency_band"]
+                            for band in asset.extra_fields.get("s3:altimetry_bands", [])
+                        ]
+                    )
+                    if bands:
+                        bands_seen |= bands
                 [self.assertTrue(band in band_list) for band in bands_seen]
                 os.remove(f"{tmp_dir}/{item_id}.json")
 


### PR DESCRIPTION
**Related Issue(s):**

Closes #26

**Description:**
Prevent EO STAC Extension from being added to altimetry products.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
