### PR TITLE
Fix TypeError: FileExtensionUpdated() takes no arguments

### DIFF
--- a/src/stactools/sentinel3/file_extension_updated.py
+++ b/src/stactools/sentinel3/file_extension_updated.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Union, cast
 
 import pystac
 from pystac.extensions.file import ByteOrder, FileExtension, MappingObject
@@ -32,10 +32,11 @@ class FileExtensionUpdated(FileExtension):
 
     @classmethod
     def ext(
-        cls, obj: pystac.Asset, add_if_missing: bool = False
+        cls, obj: Union[pystac.Asset, pystac.Link], add_if_missing: bool = False
     ) -> "FileExtensionUpdated":
-        super().ext(obj, add_if_missing)
-        return cls(obj)
+        if not isinstance(obj, pystac.Asset):
+            raise TypeError("FileExtensionUpdated only supports pystac.Asset objects.")
+        return cast(FileExtensionUpdated, super().ext(obj, add_if_missing))
 
     @classmethod
     def get_schema_uri(cls) -> str:

--- a/src/stactools/sentinel3/properties.py
+++ b/src/stactools/sentinel3/properties.py
@@ -59,7 +59,7 @@ def fill_eo_properties(eo_ext: EOExtension, manifest: XmlElement) -> None:
     def find_or_throw(attribute: str, xpath: str) -> str:
         value = manifest.find_attr(attribute, xpath)
         if value is None:
-            raise RuntimeError(f"Value not found in manifest: {xpath}@{attribute}")
+            raise RuntimeError(f"Value not in manifest: {xpath}@{attribute}")
         return value
 
     product_name = xml.find_text(manifest, ".//sentinel3:productName")


### PR DESCRIPTION
**Related Issue:**

-  https://github.com/stactools-packages/sentinel3/issues/31

**Description:**
This pull request resolves [Issue #31](https://github.com/stactools-packages/sentinel3/issues/31), addressing compatibility with the latest version of PySTAC. 
Full credit for the original fix idea goes to [@jonas-eberle](https://github.com/jonas-eberle), who implemented a similar fix ([here](https://github.com/DLR-terrabyte/stactools-sentinel3/commit/9dfbdb5f98a4f547fe5baef417e3441efeda8098)) but did not submit a pull request.

To ensure this fix benefits all users, I have incorporated and adapted it for the main repository.
In addition, I made minor adjustments to ensure that the repository's formatting, linting, and testing scripts run successfully.

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
